### PR TITLE
Nix all the things

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+{ cabal, base, deepseq, ghcjsBase, lensFamily, monadsTf
+, stdenv, transformers, void
+}:
+cabal.mkDerivation (self: {
+  pname = "react-haskell";
+  version = "1.3.0.0";
+  src = ./.;
+  buildDepends = [
+    base deepseq ghcjsBase lensFamily monadsTf transformers void
+  ];
+  homepage = "https://github.com/joelburget/react-haskell";
+  description = "Haskell React bindings";
+  meta = {
+    license = stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/react-haskell.cabal
+++ b/react-haskell.cabal
@@ -34,7 +34,7 @@ author:              Joel Burget
 maintainer:          joelburget@gmail.com
 category:            Web
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       >=1.20
 
 homepage: https://github.com/joelburget/react-haskell
 bug-reports: https://github.com/joelburget/react-haskell/issues
@@ -80,12 +80,7 @@ library
     monads-tf,
     deepseq,
     lens-family,
-    void == 0.7
-  if flag(haste-inst)
-    build-depends:
-      haste-lib >= 0.4 && <0.6
-  else
-    build-depends:
-      haste-compiler
+    void == 0.7,
+    ghcjs-base
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+{ }:
+
+with import <nixpkgs> {};
+let haskellPackages = pkgs.haskellPackages_ghcjs.override {
+      extension = self: super: {
+        oHm = self.callPackage ./. {};
+        mvc = self.callPackage ./mvc.nix {};
+      };
+    };
+
+in pkgs.callPackage ./. {
+     cabal = haskellPackages.cabal.override {
+       extension = self: super: {
+         buildTools = super.buildTools ++ [ haskellPackages.ghc.ghc.parent.cabalInstall ];
+       };
+     };
+     inherit (haskellPackages) base deepseq ghcjsBase lensFamily monadsTf transformers void;
+   }


### PR DESCRIPTION
I've replaced haste with ghcjs specfic stuff in .cabal and added a shell.nix and a default.nix.

If you have a checkout of nixpkgs you should be able to run:

```
⇒  nix-shell -I . --pure # I have a symlink to my checkout of nixpkgs in cwd                           

[nix-shell:~/dev/ghcjs/react-haskell]$ cabal configure --ghcjs
Warning: The package list for 'hackage.haskell.org' is 247.0 days old.
Run 'cabal update' to get the latest list of available packages.
Resolving dependencies...
Configuring react-haskell-1.3.0.0...

[nix-shell:~/dev/ghcjs/react-haskell]$ cabal build
Building react-haskell-1.3.0.0...
Preprocessing library react-haskell-1.3.0.0...

src/React/Anim.hs:9:8:
    Could not find module ‘Haste’
    Use -v to see a list of the files searched for.

src/React/Attrs.hs:6:8:
    Could not find module ‘Haste.JSON’
    Use -v to see a list of the files searched for.

src/React/Attrs.hs:7:8:
    Could not find module ‘Haste.Prim’
    Use -v to see a list of the files searched for.

src/React/Imports.hs:12:8:
    Could not find module ‘Haste.Foreign’
    Use -v to see a list of the files searched for.

src/React/Interpret.hs:6:8:
    Could not find module ‘Haste.DOM’
    Use -v to see a list of the files searched for.
```

So this seems to drop you into a sane nix-shell sans all the implementation changes you'd have to make to use ghcjs instead of haste :-)